### PR TITLE
Set user's email_verified_at after setting password

### DIFF
--- a/src/Http/Middleware.php
+++ b/src/Http/Middleware.php
@@ -4,6 +4,8 @@ namespace GlaivePro\Invytr\Http;
 
 use Closure;
 use GlaivePro\Invytr\Helpers\Translator;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Request;
 
 class Middleware
@@ -37,6 +39,18 @@ class Middleware
             // In case of redirect after the setting we have to remember to fix language strings again
             if (302 == $response->status()) {
                 $request->session()->put('invytr_done', true);
+            }
+            
+            /** @var User $user */
+            $user = auth()->user();
+            
+            // If the user needs email verification, password setting
+            // is enough to consider the email as verified, since they
+            // got the password set URL via email.
+            if ($user && $user instanceof MustVerifyEmail) {
+                $user->forceFill([
+                    'email_verified_at' => $user->freshTimestamp(),
+                ])->save();
             }
         }
         

--- a/src/Http/Middleware.php
+++ b/src/Http/Middleware.php
@@ -4,6 +4,7 @@ namespace GlaivePro\Invytr\Http;
 
 use Closure;
 use GlaivePro\Invytr\Helpers\Translator;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Request;

--- a/src/Http/Middleware.php
+++ b/src/Http/Middleware.php
@@ -47,10 +47,10 @@ class Middleware
             // If the user needs email verification, password setting
             // is enough to consider the email as verified, since they
             // got the password set URL via email.
-            if ($user && $user instanceof MustVerifyEmail) {
-                $user->forceFill([
-                    'email_verified_at' => $user->freshTimestamp(),
-                ])->save();
+            if ($user && $user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+                if ($user->markEmailAsVerified()) {
+                    event(new Verified($request->user()));
+                }
             }
         }
         


### PR DESCRIPTION
Fixes #3

Took a crack at implementing it, seems to work for my situation. I didn't write any tests though, would probably be best to do so. The logic is mostly taken from the `MustVerifyEmail` trait built into the Laravel auth.